### PR TITLE
Update patch.rb in opsworks_coreext cookbook to be compatible with Chef 12.22.1

### DIFF
--- a/opsworks_coreext/libraries/patch.rb
+++ b/opsworks_coreext/libraries/patch.rb
@@ -5,7 +5,7 @@ class Chef
         # windows_package resource has a bug for Chef 12.2.1
         # See https://github.com/chef/chef/issues/3316
 
-        if RUBY_PLATFORM =~ /mingw32/
+        if RUBY_PLATFORM =~ /mingw32/ && instance_methods(true).include?(:get_installed_version)
           alias_method :_get_installed_version, :get_installed_version
           def get_installed_version(product_code)
             v = _get_installed_version(product_code)


### PR DESCRIPTION
*Description of changes:*
Update patch.rb in opsworks_coreext cookbook to be compatible with Chef 12.22.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
