### PR TITLE
Update node to the latest LTS

### DIFF
--- a/opsworks_nodejs/attributes/default.rb
+++ b/opsworks_nodejs/attributes/default.rb
@@ -1,2 +1,2 @@
-default["opsworks_nodejs"]["node_version"] = "0.12.7"
-default["opsworks_nodejs"]["npm_version"] = "2.13.0"
+default["opsworks_nodejs"]["node_version"] = "20.9.0"
+default["opsworks_nodejs"]["npm_version"] = "10.1.0"

--- a/opsworks_nodejs/definitions/opsworks_nodejs_npm.rb
+++ b/opsworks_nodejs/definitions/opsworks_nodejs_npm.rb
@@ -1,16 +1,4 @@
 define :opsworks_nodejs_npm, :cwd => nil do
-
-  # Using npm cache clean to work around permissions issues. Still seem to be present in npm.
-  # See also http://blogs.msdn.com/b/matt-harrington/archive/2012/02/23/how-to-fix-node-js-npm-permission-problems.aspx
-  batch "run npm cache clean - #{params[:name]}" do
-    cwd params[:cwd]
-    code <<-EOC
-      set PATH=%APPDATA%\\npm;%PROGRAMFILES(x86)%\\nodejs;%PATH%
-      npm cache clean
-    EOC
-    only_if { ::File.file? ::File.join(params[:cwd], "package.json") }
-  end
-
   batch "run npm install - #{params[:name]}" do
     cwd params[:cwd]
     code <<-EOC

--- a/opsworks_nodejs/spec/default_spec.rb
+++ b/opsworks_nodejs/spec/default_spec.rb
@@ -15,7 +15,7 @@ describe "opsworks_nodejs::default" do
 
   context "Node.JS" do
     it "file is downloaded" do
-      expect(chef_run).to create_remote_file(File.join(Chef::Config["file_cache_path"], "node-v0.12.7-x86.msi"))
+      expect(chef_run).to create_remote_file(File.join(Chef::Config["file_cache_path"], "node-v20.9.0-x86.msi"))
     end
 
     it "node is installed" do


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
NodeJS 0.12 is 6.5 years old. This PR updates it and npm to the latest LTS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
